### PR TITLE
Adds `getRoles` function.

### DIFF
--- a/context.js
+++ b/context.js
@@ -50,3 +50,10 @@ Context.prototype.removeRole = function (name) {
   delete this.roles[name];
   this.update();
 };
+
+Context.prototype.getRoles = function (verb) {
+  var ctx = this;
+  return Object.keys(ctx.roles).filter(function (role) {
+    return (ctx.roles[role].indexOf(verb) >= 0);
+  });
+};

--- a/index.js
+++ b/index.js
@@ -95,7 +95,7 @@ relations.define = function (name, structure) {
     queue(cmd);
   };
 
-  ['addRole', 'updateRole', 'removeRole'].forEach(function (method) {
+  ['addRole', 'updateRole', 'removeRole', 'getRoles'].forEach(function (method) {
     relations[name][method] = ctx[method].bind(ctx);
   });
 };

--- a/test/common.js
+++ b/test/common.js
@@ -207,4 +207,12 @@ doBasicTest = function (store, options) {
       done();
     });
   });
+
+  it('what roles can absquatulate?', function (done) {
+    var roles = relations.repos.getRoles('absquatulate');
+    assert(roles);
+    assert.equal(roles.length, 1);
+    assert.equal(roles[0], 'owner');
+    done();
+  });
 }


### PR DESCRIPTION
In our use of node relations, we take advantage of dynamic roles to define a permissions schema where the `role` is really a Team id and all the `subject`s are members of that team. It would be useful for us to be able to access the in-memory definition of what `roles` map to a `verb`. For example, we may want to ask what team can execute an action, rather than asking who the subjects are. 

This PR adds what seems like a pretty simply addition of a `getRoles` function, which returns a filtered list of all the roles in a context that map to a specified verb. 
